### PR TITLE
added onlyOnceForEachNode function to start a task on the first worke…

### DIFF
--- a/include/PGASUS/tasking/tasking.hpp
+++ b/include/PGASUS/tasking/tasking.hpp
@@ -58,6 +58,13 @@ TaskRef<T> async(const numa::tasking::TaskFunction<T> &fun, Priority prio, const
 PGASUS_EXPORT std::list<TriggerableRef> forEachThread(
 	const NodeList &nodes, const numa::tasking::TaskFunction<void> &fun, Priority prio);
 
+/**
+ * Spawns the given task once on the first worker thread's task queue on all
+ * the given nodes
+ */
+PGASUS_EXPORT std::list<TriggerableRef> onceForEachNode(
+	const NodeList &nodes, const numa::tasking::TaskFunction<void> &fun, Priority prio);
+
 template <class T>
 struct DistributedExec {
 	typedef std::vector<T> ResultType;


### PR DESCRIPTION
This pull request adds a new function to the PGASUS tasking that allows to spawn a task once on the first worker thread of each node. This is useful to set up datastructures locally once per node and required to build the latest version of presleybench with pgasus integration.